### PR TITLE
Allow the plugin to load on non-Windows platforms

### DIFF
--- a/changelog.d/20230714_220759_kurtmckee_support_import_without_winreg.rst
+++ b/changelog.d/20230714_220759_kurtmckee_support_import_without_winreg.rst
@@ -1,0 +1,7 @@
+Fixed
+-----
+
+-   Allow the plugin to load on non-Windows platforms.
+
+    This allows non-Windows operating systems to load the plugin
+    without resulting in an ``ImportError``.

--- a/dotbot_windows.py
+++ b/dotbot_windows.py
@@ -11,7 +11,12 @@ import pathlib
 import subprocess
 import sys
 import typing
-import winreg
+
+# Protect cross-platform plugin loading.
+try:
+    import winreg
+except ImportError:
+    winreg = None  # type: ignore[assignment]
 
 import dotbot.plugin
 
@@ -52,7 +57,7 @@ class Windows(dotbot.plugin.Plugin):  # type: ignore[misc]
                 "Check the debug logs for more information."
             )
 
-        if not sys.platform.startswith("win32"):
+        if not sys.platform.startswith("win32") or winreg is None:
             self._log.warning(
                 f"The Windows plugin cannot run on '{sys.platform}' platforms."
             )


### PR DESCRIPTION
Fixed
-----

-   Allow the plugin to load on non-Windows platforms.

    This allows non-Windows operating systems to load the plugin
    without resulting in an ``ImportError``.
