### PR TITLE
Migrate to Poetry's `package-mode` option

### DIFF
--- a/requirements/mypy/pyproject.toml
+++ b/requirements/mypy/pyproject.toml
@@ -1,13 +1,6 @@
 [tool.poetry]
-name = "mypy requirements"
-version = "0"
-description = ""
-authors = []
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.8"
 mypy = "*"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"

--- a/requirements/test/pyproject.toml
+++ b/requirements/test/pyproject.toml
@@ -1,8 +1,5 @@
 [tool.poetry]
-name = "test requirements"
-version = "0"
-description = ""
-authors = []
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.8"
@@ -11,7 +8,3 @@ pytest = "*"
 pytest-randomly = "*"
 pyfakefs = "*"
 tomli = {version = "*", markers = "python_version < '3.11'"}
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION

This PR migrates the dummy package values in `requirements/*/pyproject.toml` files to Poetry's new `package-mode = false` option.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>