### PR TITLE
Remove the redundant tox `skip_missing_interpreters` setting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
+min_version = 4.4.4
 envlist =
     coverage-erase
     py{3.12, 3.11, 3.10, 3.9, 3.8}
     coverage-report
     mypy
-
-min_version = 4.4.4
-skip_missing_interpreters = true
 labels =
     update=update
 


### PR DESCRIPTION

This PR removes the redundant tox `skip_missing_interpreters` setting in `tox.ini`.
This codifies the recently-discovered fact that it's true by default.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>