### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
       - id: "black"
 
   - repo: "https://github.com/pycqa/isort"
-    rev: "5.13.2"
+    rev: "6.0.0"
     hooks:
       - id: "isort"
 
@@ -45,10 +45,10 @@ repos:
     hooks:
       - id: "flake8"
         additional_dependencies:
-          - "flake8-bugbear==24.10.31"
+          - "flake8-bugbear==24.12.12"
 
   - repo: "https://github.com/python-jsonschema/check-jsonschema"
-    rev: "0.30.0"
+    rev: "0.31.0"
     hooks:
       - id: "check-dependabot"
       - id: "check-github-workflows"


### PR DESCRIPTION

This resolves pre-commit deprecation warnings about isort.
Also, switch to plain old editorconfig-checker.